### PR TITLE
fix: resolve biome formatting errors

### DIFF
--- a/packages/musher/package.json
+++ b/packages/musher/package.json
@@ -19,9 +19,7 @@
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",
 		"check": "pnpm check:format && pnpm check:lint && pnpm check:types && pnpm check:test",
@@ -55,11 +53,5 @@
 		"url": "git+https://github.com/musher-dev/typescript-sdk.git",
 		"directory": "packages/musher"
 	},
-	"keywords": [
-		"musher",
-		"bundle",
-		"sdk",
-		"ai",
-		"agent"
-	]
+	"keywords": ["musher", "bundle", "sdk", "ai", "agent"]
 }


### PR DESCRIPTION
## Summary
- Fix Biome formatting in `packages/musher/package.json` (collapse `files` and `keywords` arrays to single lines)
- Fix CRLF line endings in `.github/release-please/manifest.json`

## Test plan
- [x] `pnpm biome ci .` passes locally
- [ ] CI check job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)