### PR TITLE
fix: resolve biome formatting after release-please bump

### DIFF
--- a/packages/musher/package.json
+++ b/packages/musher/package.json
@@ -19,9 +19,7 @@
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build": "tsup",
 		"check": "pnpm check:format && pnpm check:lint && pnpm check:types && pnpm check:test",
@@ -55,11 +53,5 @@
 		"url": "git+https://github.com/musher-dev/typescript-sdk.git",
 		"directory": "packages/musher"
 	},
-	"keywords": [
-		"musher",
-		"bundle",
-		"sdk",
-		"ai",
-		"agent"
-	]
+	"keywords": ["musher", "bundle", "sdk", "ai", "agent"]
 }


### PR DESCRIPTION
## Summary
- Fix Biome formatting in `packages/musher/package.json` — release-please PR #9 (v0.1.3 bump) re-expanded the `files` and `keywords` arrays to multi-line, undoing PR #8's fix

## Test plan
- [x] `pnpm biome ci .` passes locally
- [x] All other CI checks pass locally (types, tests, exports, build, publint, attw)
- [ ] CI check job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)