### PR TITLE
fix!: replace `agent_definition` asset type with `agent_spec`

### DIFF
--- a/packages/musher/src/bundle.ts
+++ b/packages/musher/src/bundle.ts
@@ -88,7 +88,7 @@ export class Bundle {
 					this._toolsets.set(name, new ToolsetHandle(name, fh));
 					break;
 				}
-				case "agent_definition": {
+				case "agent_spec": {
 					const name = baseFileName(fh.logicalPath);
 					this._agentSpecs.set(name, new AgentSpecHandle(name, fh));
 					break;

--- a/packages/musher/src/handles/agent-spec-handle.ts
+++ b/packages/musher/src/handles/agent-spec-handle.ts
@@ -1,5 +1,5 @@
 /**
- * AgentSpecHandle — wraps a single agent_definition asset.
+ * AgentSpecHandle — wraps a single agent_spec asset.
  */
 
 import type { FileHandle } from "./file-handle.js";

--- a/packages/musher/src/schemas/common.ts
+++ b/packages/musher/src/schemas/common.ts
@@ -7,7 +7,7 @@ export const BundleVisibility = z.enum(["private", "public"]);
 export const BundleVersionState = z.enum(["published", "yanked"]);
 
 export const AssetType = z.enum([
-	"agent_definition",
+	"agent_spec",
 	"skill",
 	"tool_config",
 	"prompt",

--- a/packages/musher/tests/bundle.test.ts
+++ b/packages/musher/tests/bundle.test.ts
@@ -62,7 +62,7 @@ function makeManifest(): BundleResolveOutput {
 				{
 					assetId: "asset-005",
 					logicalPath: "agents/main.yaml",
-					assetType: "agent_definition",
+					assetType: "agent_spec",
 					contentSha256: sha(AGENT_CONTENT),
 					sizeBytes: AGENT_CONTENT.length,
 				},

--- a/packages/musher/tests/handles.test.ts
+++ b/packages/musher/tests/handles.test.ts
@@ -90,7 +90,7 @@ describe("ToolsetHandle", () => {
 
 describe("AgentSpecHandle", () => {
 	it("wraps a single file", () => {
-		const fh = new FileHandle("agent.yaml", "agent_definition", "x", 4, Buffer.from("name"));
+		const fh = new FileHandle("agent.yaml", "agent_spec", "x", 4, Buffer.from("name"));
 		const spec = new AgentSpecHandle("agent", fh);
 
 		expect(spec.name).toBe("agent");


### PR DESCRIPTION
## Summary

- Replaces `agent_definition` with `agent_spec` in the `AssetType` enum to match the platform API's wire format
- Updates the `Bundle` constructor to match on `agent_spec` instead of `agent_definition`
- Updates doc comments and tests accordingly

**Root cause:** The platform API returns `"agent_spec"` for agent assets, but the SDK only recognized `"agent_definition"`, causing `bundle.agentSpecs()` to always return an empty array.

**Closes:** musher-dev/platform#335

## Test plan

- [x] All 141 unit tests pass (`task check`)
- [x] Verified against live platform — `bundle.agentSpecs()` now correctly returns agent specs from `sdk-test-bot/e2e-kitchen-sink:0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)